### PR TITLE
Update column names in input csv

### DIFF
--- a/docs/input_csv.md
+++ b/docs/input_csv.md
@@ -1,13 +1,16 @@
 # Input CSV
 To build a template, provide a CSV with information about the images you'd like to use. Each line in the CSV represents a stack of images.
 
+See Brainglobe's [image space definition documentation](https://brainglobe.info/documentation/setting-up/image-definition.html) 
+for further information about defining image axis 0/1/2 and the origin.
+
 ## Required Columns
 - `subject_id`: Unique identifier for the subject. Do not use spaces, hyphens (`-`) or underscores (`_`).
-- `resolution_z`: Voxel resolution in the Z axis (in μm)
-- `resolution_y`: Voxel resolution in the Y axis (in μm)
-- `resolution_x`: Voxel resolution in the X axis (in μm)
+- `resolution_0`: Voxel resolution of axis 0 (in μm)
+- `resolution_1`: Voxel resolution of axis 1 (in μm)
+- `resolution_2`: Voxel resolution of axis 2 (in μm)
 - `origin`: 3-letter anatomical orientation code (e.g., `PSL`, `LSP`, `RAS`). See the [`AnatomicalSpace`](https://github.com/brainglobe/brainglobe-space/blob/1f2e3056fb35de87b962355f263a1462ce1dec53/brainglobe_space/core.py#L30) docstring for more context.
-- `source_filepath`: Full path to the source image stack
+- `filepath`: Full path to the image stack
 
 ## Optional Columns
 - `species`: Species name
@@ -22,7 +25,7 @@ To build a template, provide a CSV with information about the images you'd like 
 ## Example
 
 ```csv
-subject_id,resolution_z,resolution_y,resolution_x,origin,source_filepath,species,sex
+subject_id,resolution_0,resolution_1,resolution_2,origin,filepath,species,sex
 ZF1,25,25,25,PSL,/ceph/atlas-forge/zebrafinch/sourcedata/ZF1_25_25_ch03_green.tif,Zebra finch,F
 ZF2,25,25,25,PSL,/ceph/atlas-forge/zebrafinch/sourcedata/ZF2_25_25_ch03_green.tif,Zebra finch,M
 ZF3,25,25,25,PSL,/ceph/atlas-forge/zebrafinch/sourcedata/ZF3_25_25_ch03_chan_3_green.tif,Zebra finch,F


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
As discussed on the following issues: https://github.com/brainglobe/atlas-forge/issues/15 and https://github.com/brainglobe/atlas-forge/issues/18 , we need to re-name some of the input csv columns.

**What does this PR do?**
- renames `resolution_z`, `resolution_y`, `resolution_x` to `resolution_0`, `resolution_1`, `resolution_2`
- replaces `source_filepath` with `filepath`
- adds a link to the brainglobe image space definition docs

Once this has been merged, I'll update the relevant functions in `brainglobe-template-builder` to match this new naming scheme.

## References

Related to https://github.com/brainglobe/atlas-forge/issues/15 and https://github.com/brainglobe/atlas-forge/issues/18

## How has this PR been tested?

N/A

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Documentation has been updated.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
