### PR TITLE
code used for 3um crab

### DIFF
--- a/crab/downsample_raw_crab.py
+++ b/crab/downsample_raw_crab.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import nd2
+from brainglobe_template_builder.utils.transform_utils import downsample_anisotropic_stack_to_isotropic
+from brainglobe_utils.IO.image.save import save_any
+import dask.array as da
+import os
+    
+input_dir = Path("/media/ceph/microscopy/collaborative_projects/crab_atlas")
+output_dir = Path("/media/ceph/zoo/raw/CrabLab/Anatomy/crab_atlas/downsampled/")
+target_resolution_um = 3
+    
+for subfolder in input_dir.iterdir():
+    print(f"Started {subfolder.name}")
+    if not subfolder.is_dir():
+        continue
+    
+    assert subfolder.name.startswith("Atl"), f"Subfolder name must start with 'Atl': {subfolder.name}"
+    
+    nd2_file = subfolder / f"{subfolder.name}-Stitched.nd2"
+
+    if nd2_file.exists():
+        data = nd2.imread(str(nd2_file))
+        print(data.shape)
+        for channel_index, channel_name in enumerate(["autofluorescence", "cytox", "WGA"]):
+            channel_data = data[:, channel_index, :, :] 
+            print(channel_data.shape)
+            channel_data = da.from_array(channel_data, chunks={0: 1, 1: channel_data.shape[1], 2: channel_data.shape[2]})
+            channel_data = downsample_anisotropic_stack_to_isotropic(channel_data,(3, 0.86, 0.86), target_resolution_um)
+            save_any(channel_data, Path.home()/"crab_test"/f"{subfolder.name}_{target_resolution_um}um_{channel_name}.tif")
+            Path.mkdir(output_dir/f"{subfolder.name}/{target_resolution_um}um/", exist_ok=True, parents=True)
+            save_any(channel_data, output_dir/f"{subfolder.name}/{target_resolution_um}um/{subfolder.name}_{target_resolution_um}um_{channel_name}.tif")
+            print(f"Saved {channel_name}")
+        print(f"Finished {subfolder.name}")
+    else:
+        print(f"Skipping {nd2_file} because it does not exist")

--- a/crab/preprocess_crab.py
+++ b/crab/preprocess_crab.py
@@ -5,5 +5,5 @@ from pathlib import Path
 
 if __name__ == "__main__":
     output_dir = Path("/home/alessandro/crab_atlas_forge")
-    config = PreprocConfig(output_dir=output_dir, mask=MaskConfig(gaussian_sigma=6, closing_size=10))  # couble defaults for double-resolution
+    config = PreprocConfig(output_dir=output_dir, mask=MaskConfig(gaussian_sigma=6, closing_size=10))  # double defaults for double-resolution
     preprocess(output_dir/"standardised/standardised_images.csv", config=config)

--- a/crab/preprocess_crab.py
+++ b/crab/preprocess_crab.py
@@ -1,9 +1,9 @@
 
-from brainglobe_template_builder.preproc.preprocess import preprocess
-from brainglobe_template_builder.preproc.preproc_config import PreprocConfig, MaskConfig
+from brainglobe_template_builder.preprocess import preprocess
+from brainglobe_template_builder.utils.preproc_config import PreprocConfig, MaskConfig
 from pathlib import Path
 
 if __name__ == "__main__":
-    output_dir = Path("/media/ceph/neuroinformatics/neuroinformatics/atlas-forge/Crab/")
-    config = PreprocConfig(output_dir=output_dir, mask=MaskConfig()) # default mask, will use manual ones anyway
-    preprocess(output_dir/"raw/raw_images.csv", config=config)
+    output_dir = Path("/home/alessandro/crab_atlas_forge")
+    config = PreprocConfig(output_dir=output_dir, mask=MaskConfig(gaussian_sigma=6, closing_size=10))  # couble defaults for double-resolution
+    preprocess(output_dir/"standardised/standardised_images.csv", config=config)

--- a/crab/standardise_crab.py
+++ b/crab/standardise_crab.py
@@ -1,9 +1,9 @@
-from brainglobe_template_builder.preproc.standardise import standardise
+from brainglobe_template_builder.standardise import standardise
 
 from pathlib import Path
 if __name__ == "__main__":
-    source_csv = Path("/media/ceph/zoo/raw/CrabLab/Anatomy/crab_atlas/atlas-generation-Afruca-tangeri-metadata-AF.csv")
-    output_dir = Path("/media/ceph/neuroinformatics/neuroinformatics/atlas-forge/Crab/")
-    output_vox_size = None # already at 6 micron, no downsampling needed
+    source_csv = Path("/home/alessandro/crab_test/3um/template-building-crab-3um-april-2026.csv")
+    output_dir = Path("/home/alessandro/crab_atlas_forge")
+    output_vox_size = None # already at 3 micron, no downsampling needed
     standardise(source_csv=source_csv, output_dir=output_dir, output_vox_size=output_vox_size)
  

--- a/crab/template-building-crab-3um-april-2026.csv
+++ b/crab/template-building-crab-3um-april-2026.csv
@@ -1,0 +1,10 @@
+subject_id,resolution_0,resolution_1,resolution_2,origin,filepath,mask_filepath,use
+Atl20L,3,3,3,IPR,/home/alessandro/crab_test/3um/Atl20L_3um_WGA.tif,,TRUE
+Atl21L,3,3,3,IPR,/home/alessandro/crab_test/3um/Atl21L_3um_WGA.tif,,TRUE
+Atl22R,3,3,3,SAR,/home/alessandro/crab_test/3um/Atl22R_3um_WGA.tif,,TRUE
+Atl23R,3,3,3,SRP,/home/alessandro/crab_test/3um/Atl23R_3um_WGA.tif,,TRUE
+Atl24R,3,3,3,IAL,/home/alessandro/crab_test/3um/Atl24R_3um_WGA.tif,,TRUE
+Atl25R,3,3,3,IRA,/home/alessandro/crab_test/3um/Atl25R_3um_WGA.tif,,TRUE
+Atl27R,3,3,3,SLA,/home/alessandro/crab_test/3um/Atl27R_3um_WGA.tif,,TRUE
+Atl28L,3,3,3,SRP,/home/alessandro/crab_test/3um/Atl28L_3um_WGA.tif,,TRUE
+Atl29L,3,3,3,SRP,/home/alessandro/crab_test/3um/Atl29L_3um_WGA.tif,,TRUE


### PR DESCRIPTION
## Description

**What is this PR**

This PR marks the state of the code as I used it to create a high-res crab template at 3um.
Mainly adding this for reproducibility reasons, and as a reference for us and maybe others - especially if this template ends up being the one we publish at conferences or in journals, and we need to write a Methods section :) .

It adds
* a custom pre-pre-processing step that acts as glue between the confocal `nd2` images and our usual pipeline
* code adaptations of paths to run locally, and the csv I used
* code adaptation to newer template-builder API

## References

## How has this PR been tested?

```bash
modelbuild.sh --output-dir /home/alessandro/crab_atlas_forge/template_3um_automasks --stages rigid,similarity,affine,nlin --average-type efficient_trimean --average-prog python --masks /home/alessandro/crab_atlas_forge/template_3um_automasks/all_processed_mask_paths.txt /home/alessandro/crab_atlas_forge/template_3um_automasks/all_processed_brain_paths.txt 
```

 gave a reasonable template after preprocessing.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally - manually.
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
